### PR TITLE
refactor: improve response handling and simplify configuration parsing

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -62,7 +62,7 @@ func (c *dohDNSClient) Query(ctx context.Context, dnsreq []byte) (r *dns.Msg, er
 	if resp, err = c.client.Do(req); err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer dumpRemainingResponse(resp)
 
 	// RFC8484 Section 4.2.1:
 	// A successful HTTP response with a 2xx status code is used for any valid DNS response,
@@ -85,6 +85,13 @@ func (c *dohDNSClient) Query(ctx context.Context, dnsreq []byte) (r *dns.Msg, er
 	r = new(dns.Msg)
 	err = r.Unpack(body)
 	return
+}
+
+func dumpRemainingResponse(res *http.Response) {
+	if res != nil {
+		_, _ = io.Copy(io.Discard, res.Body)
+		res.Body.Close()
+	}
 }
 
 type metricDNSClient struct {


### PR DESCRIPTION
This pull request includes several changes to improve the handling of HTTP responses, simplify the configuration parsing, and refactor the code for better readability and maintainability. The most important changes are summarized below:

### HTTP Response Handling:

* Replaced `defer resp.Body.Close()` with a new function `dumpRemainingResponse` to ensure the response body is fully read and closed. (`proxy.go`) [[1]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L65-R65) [[2]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499R90-R96)

### Configuration Parsing:

* Simplified the `parseConfig` function by refactoring the parsing of `toURLs` into a separate function `parseToURLs` and combining error checks. (`setup.go`) [[1]](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL67-L94) [[2]](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL112-R121)
* Changed the `parseExcept` function to return an error directly instead of using named return values. (`setup.go`)

### Code Refactoring:

* Consolidated the creation of the `http.Client` and its `Transport` into a single initialization block. (`setup.go`)
* Simplified the `parseTLS` function by passing the remaining arguments directly to `pkgtls.NewTLSConfigFromArgs`. (`setup.go`)